### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM gcc
+
+COPY . /src/osmctools/
+WORKDIR /src/osmctools/
+
+RUN autoreconf --install
+RUN ./configure
+RUN make
+RUN make install


### PR DESCRIPTION
Add Dockerfile to enable image building. Useful for development and tests under Docker workflow.
Using the official GCC image, latest tag. More info at https://hub.docker.com/_/gcc/

Just adding files, setting working dir and running build instructions

Build:

```
$ docker build -t osmctools .
```

Run:

```
$ docker run --rm -it [-v /any_dir_on_your_host/with_map_data/:/data/] osmctools [osmctools tool and options or nothing for bash]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
docker run --rm -it [-v /any_dir_on_your_host/with_map_data/:/data/] osmctools pataquets/osmctools-src
```

Using `--rm` causes the container to be deleted after stop.
You will need to add ```-v``` switch in order to mount your host's maps dir inside the container's filesystem.

Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it, if needed.